### PR TITLE
Update README with Lua usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,18 @@ Toggle UI elements effortlessly.
 
 ## Usage
 
-```fennel
-(local M (require :toggler))
+```lua
+local M = require('toggler')
 
-; register ui element
-(M.register :qf {:open (fn [] (vim.cmd :copen))
-                 :close (fn [] (vim.cmd :cclose))
-                 :is_open (fn []
-                            (not= (-> (vim.fn.getqflist {:winid 0})
-                                      (. :winid))
-                                  0))})
+-- register ui element
+M.register('qf', {
+  open = function() vim.cmd('copen') end,
+  close = function() vim.cmd('cclose') end,
+  is_open = function()
+    return vim.fn.getqflist({winid = 0}).winid ~= 0
+  end
+})
 
-; toggle ui element
-; (M.toggle :qf)
+-- toggle ui element
+M.toggle('qf')
 ```


### PR DESCRIPTION
Update `README.md` to provide Lua usage example instead of Fennel.

* Replace Fennel usage example with Lua equivalent.
* Use `require('toggler')` to import the module.
* Use `M.register` to register the UI element with `id` and `opts`.
* Use `M.toggle` to toggle the registered UI element.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ttak0422/toggler-nvim/pull/1?shareId=f778f455-67cc-4faf-af08-9547e65fea59).